### PR TITLE
v0.1.1 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,4 @@
-#### 0.1.0 November 02 2021 ####
-First release
+#### 0.1.1 November 02 2021 ####
+
+* Added detailed XML-DOC comments for all of the `BackpressureAlert` extension methods
+* Added support for attaching `BackpressureAlert` to `SubFlow<TOut, TMat, TClosed>`

--- a/src/Aaron.Akka.Streams.BackpressureMonitor.Tests/BackpressureAlertSpecs.cs
+++ b/src/Aaron.Akka.Streams.BackpressureMonitor.Tests/BackpressureAlertSpecs.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Aaron.Akka.Streams.Dsl;
+using Akka;
 using Akka.Event;
 using Akka.Streams;
 using Akka.Streams.Dsl;
@@ -64,6 +66,33 @@ namespace Aaron.Akka.Streams.BackpressureMonitor.Tests
                             await Task.Delay(100);
                             return i;
                         })
+                        .RunWith(Sink.Ignore<int>(), Sys.Materializer());
+
+                    await source;
+                });
+            });
+        }
+        
+        [Fact(Skip = "Racy, but does verify that the stage logs")]
+        public async Task ShouldLogWithBackpressureWithSubflows()
+        {
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+            {
+                await EventFilter.Info(contains: "backpressure").ExpectAsync(30, RemainingOrDefault, async () =>
+                {
+                    var parallelProcessing = (Flow<int, int, NotUsed>)Flow.Create<int>()
+                        .GroupBy(10, i => i % 10)
+                        //.Grouped(1)
+                        .BackpressureAlert(LogLevel.InfoLevel)
+                        .SelectAsync(1, async i =>
+                        {
+                            await Task.Delay(100);
+                            return i;
+                        })
+                        .MergeSubstreams();
+                    
+                    var source = Source.From(Enumerable.Range(0, 20))
+                        .Via(parallelProcessing)
                         .RunWith(Sink.Ignore<int>(), Sys.Materializer());
 
                     await source;

--- a/src/Aaron.Akka.Streams.BackpressureMonitor/BackpressureAlert.cs
+++ b/src/Aaron.Akka.Streams.BackpressureMonitor/BackpressureAlert.cs
@@ -17,16 +17,85 @@ namespace Aaron.Akka.Streams.Dsl
         /// </summary>
         private static readonly TimeSpan DefaultBackPressureThreshold = TimeSpan.FromMilliseconds(40);
         
-        public static IFlow<T, TMat> BackpressureAlert<T, TMat>(this IFlow<T, TMat> flow,
+        /// <summary>
+        /// Creates a BackpressureAlert stage that logs backpressure messages at the configured loglevel
+        /// and also records how long backpressure was observed prior to receiving a fresh Pull from
+        /// downstream.
+        /// </summary>
+        /// <param name="flow">The upstream <see cref="Flow{TIn,TOut,TMat}"/></param>
+        /// <param name="backPressureLogLevel">
+        ///     The <see cref="LogLevel"/> to record backpressure warnings.
+        ///     Defaults to <see cref="LogLevel.DebugLevel"/>.
+        /// </param>
+        /// <param name="backpressureThreshold">
+        ///     The minimum duration to test for backpressure. Defaults to 40ms.
+        ///     The higher this value, the less sensitivity this alert has to backpressure.
+        /// </param>
+        /// <typeparam name="TIn">Input type.</typeparam>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="TMat">Materialization type.</typeparam>
+        /// <returns>A new <see cref="Flow{TIn,TOut,TMat}"/></returns>
+        public static Flow<TIn, TOut, TMat> BackpressureAlert<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow,
+            LogLevel backPressureLogLevel = LogLevel.DebugLevel, TimeSpan? backpressureThreshold = null)
+        {
+            return (Flow<TIn, TOut, TMat>)InternalBackpressureAlert(flow, backPressureLogLevel, backpressureThreshold);
+        }
+        
+        /// <summary>
+        /// INTERNAL API
+        /// </summary>
+        private static IFlow<T, TMat> InternalBackpressureAlert<T, TMat>(this IFlow<T, TMat> flow,
             LogLevel backPressureLogLevel = LogLevel.DebugLevel, TimeSpan? backpressureThreshold = null)
         {
             return flow.Via(new BackpressureAlert<T>(backpressureThreshold ?? DefaultBackPressureThreshold, backPressureLogLevel));
         }
-        
-        public static Source<T, TMat> BackpressureAlert<T, TMat>(this Source<T, TMat> flow, 
+
+        /// <summary>
+        /// Creates a BackpressureAlert stage that logs backpressure messages at the configured loglevel
+        /// and also records how long backpressure was observed prior to receiving a fresh Pull from
+        /// downstream.
+        /// </summary>
+        /// <param name="flow">The upstream <see cref="Flow{TIn,TOut,TMat}"/></param>
+        /// <param name="backPressureLogLevel">
+        ///     The <see cref="LogLevel"/> to record backpressure warnings.
+        ///     Defaults to <see cref="LogLevel.DebugLevel"/>.
+        /// </param>
+        /// <param name="backpressureThreshold">
+        ///     The minimum duration to test for backpressure. Defaults to 40ms.
+        ///     The higher this value, the less sensitivity this alert has to backpressure.
+        /// </param>
+        /// <typeparam name="T">Output type.</typeparam>
+        /// <typeparam name="TMat">Materialization type.</typeparam>
+        /// <returns>A new <see cref="Source{T,TMat}"/></returns>
+        public static Source<T, TMat> BackpressureAlert<T, TMat>(this Source<T, TMat> flow,
             LogLevel backPressureLogLevel = LogLevel.DebugLevel, TimeSpan? backpressureThreshold = null)
         {
-            return flow.Via(new BackpressureAlert<T>(backpressureThreshold ?? DefaultBackPressureThreshold, backPressureLogLevel));
+            return (Source<T, TMat>) InternalBackpressureAlert(flow, backPressureLogLevel, backpressureThreshold);
+        }
+
+        /// <summary>
+        /// Creates a BackpressureAlert stage that logs backpressure messages at the configured loglevel
+        /// and also records how long backpressure was observed prior to receiving a fresh Pull from
+        /// downstream.
+        /// </summary>
+        /// <param name="flow">The upstream <see cref="Flow{TIn,TOut,TMat}"/></param>
+        /// <param name="backPressureLogLevel">
+        ///     The <see cref="LogLevel"/> to record backpressure warnings.
+        ///     Defaults to <see cref="LogLevel.DebugLevel"/>.
+        /// </param>
+        /// <param name="backpressureThreshold">
+        ///     The minimum duration to test for backpressure. Defaults to 40ms.
+        ///     The higher this value, the less sensitivity this alert has to backpressure.
+        /// </param>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="TMat">Materialization type.</typeparam>
+        /// <typeparam name="TClosed">The key type.</typeparam>
+        /// <returns>A new <see cref="SubFlow{TOut,TMat,TClosed}"/></returns>
+        public static SubFlow<TOut, TMat, TClosed> BackpressureAlert<TOut, TMat, TClosed>(
+            this SubFlow<TOut, TMat, TClosed> flow, LogLevel backPressureLogLevel = LogLevel.DebugLevel,
+            TimeSpan? backpressureThreshold = null)
+        {
+            return (SubFlow<TOut, TMat, TClosed>)InternalBackpressureAlert(flow, backPressureLogLevel, backpressureThreshold);
         }
     }
     
@@ -133,7 +202,5 @@ namespace Aaron.Akka.Streams.Dsl
         /// </summary>
         /// <returns>TBD</returns>
         public override string ToString() => $"BackpressureAlert<{typeof(T)}>";
-
-        
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2020-2021 Aaron Stannard</Copyright>
     <Authors>Aaronontheweb</Authors>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>First release</PackageReleaseNotes>
+    <VersionPrefix>0.1.1</VersionPrefix>
+    <PackageReleaseNotes>Added detailed XML-DOC comments for all of the `BackpressureAlert` extension methods
+Added support for attaching `BackpressureAlert` to `SubFlow&lt;TOut, TMat, TClosed&gt;`</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
#### 0.1.1 November 02 2021 ####

* Added detailed XML-DOC comments for all of the `BackpressureAlert` extension methods
* Added support for attaching `BackpressureAlert` to `SubFlow<TOut, TMat, TClosed>`